### PR TITLE
Add workflow permissions

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,0 +1,29 @@
+name: Test and Deploy
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches-ignore: ['gh-pages']
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run dummy tests
+        run: echo "No tests configured"
+
+  deploy:
+    needs: test
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: .


### PR DESCRIPTION
## Summary
- add GitHub workflow with `contents: write` permission
- ignore pushes to `gh-pages`

## Testing
- `node tests/calculation_tests.js`

------
https://chatgpt.com/codex/tasks/task_e_68577e0058d4832f9c72d447d47a4e5a